### PR TITLE
do not COPY the file not in repository

### DIFF
--- a/yolox-docker/Dockerfile
+++ b/yolox-docker/Dockerfile
@@ -27,4 +27,4 @@ RUN cd /root/YOLOX && wget https://github.com/Megvii-BaseDetection/YOLOX/release
 RUN cd /root/ && git clone https://github.com/NVIDIA-AI-IOT/torch2trt ; cd torch2trt; python3 setup.py install
 RUN cd /root/YOLOX && python3 tools/trt.py -n yolox-s -c yolox_s.pth ; python3 tools/trt.py -n yolox-tiny -c yolox_tiny.pth
 COPY prepare.sh /root/YOLOX
-COPY run_webcam.sh /root/YOLOX
+# COPY run_webcam.sh /root/YOLOX


### PR DESCRIPTION
# why
- docker build に失敗する不具合あり。
# what
- gitに登録していないファイルにCOPY を実行していたことが原因。
- そのファイルへのCOPYをやめた。