### PR TITLE
Feature/color order output

### DIFF
--- a/grounded-sam-docker/grounded_sam_demo_my.py
+++ b/grounded-sam-docker/grounded_sam_demo_my.py
@@ -163,7 +163,7 @@ def save_mask_data(output_dir: Path, mask_list, box_list: List, label_list: List
         json.dump(json_data, f)
 
 def save_output(output_dir: Path, masks: List, boxes_filt: List, pred_phrases: List[str], image: np.ndarray):
-    bgrimage = cv2.cvtColor(image, color=cv2.COLOR_BGR2RGB)
+    bgrimage = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     plt.figure(figsize=(10, 10))
     plt.imshow(bgrimage)
     for mask in masks:


### PR DESCRIPTION
# why
- output/grounded_sam_output.png の表示の色が原画像と異なっている。
- OpenCVはBGRの順序, matplotlibはRGBを期待していることに起因している。
# what
- 色の違いを生じないように、save_output() を改変した。

# 目視確認
- bash test_demo1_my.sh を実行し、
- output/grounded_sam_output.png のbearのbounding box 、　セグメンテーションの結果を確認する。
