### PR TITLE
removed doubled colorize

### DIFF
--- a/grounded-sam-docker/gsam.py
+++ b/grounded-sam-docker/gsam.py
@@ -314,7 +314,7 @@ class GroundedSAMPredictor:
         self.pred_phrases = pred_phrases
         self.masks = masks
         self.boxes_filt = boxes_filt
-        self.colorized = colorize(gen_mask_img(masks).numpy())
+        # self.colorized = colorize(gen_mask_img(masks).numpy())
         self.used = used
 
 


### PR DESCRIPTION
# why
- colorize() の呼び出しが2箇所にあった。
- colorize()は、人の視認による確認用の処理。
# what
- infer_all()の中では、推論で必須なことだけにするようにした。
